### PR TITLE
Admin policy

### DIFF
--- a/admin-policy.md
+++ b/admin-policy.md
@@ -32,7 +32,7 @@ This posts documents how the HX group will be run and administered. The policies
 
 Note that there are many tasks such as Hackbot administration, Github projects, etc. that do not need to be solely managed by admins.
 
-## Post deletion
+## Deletion of Posts
 
 We believe that posts should only be deleted in a few specific cases. First of all, any spam from hacked accounts or bots will be deleted. Second, any posts violating Facebook's content policies will also be deleted. Finally, content can be deleted by an admin if the content is harassing a *specific* user, and that user requests that the content be removed. Note that generally objectionable content that does not target a *specific* user will not be removed (unless it violates Facebook's content policies), and will only be closed instead.
 
@@ -49,4 +49,6 @@ The purpose of this process is both to give users a second chance, and to have a
 
 ## GitHub
 
-[TODO: Ian, fill this in]
+Anyone can be given read access to our GitHub organization `wearehx`. The current administration team is always given Owner access on the organization. Other users should retain their previous privileges, but the current administration team has the final say and can make modifications as needed.
+
+Projects must be approved by anyone with Owner access and will be given a team on the organization, if needed. Projects must have a `CONTRIBUTING.md` and `README.md` file to document what the project is and how to contribute. Incomplete projects should be removed after a reasonable amount of time; inactive projects should be removed only if the repository serves no purpose to anyone, even outside the group.

--- a/admin-policy.md
+++ b/admin-policy.md
@@ -1,0 +1,43 @@
+# HX Administration Policy
+
+## Introduction
+
+This posts documents how the HX group will be run and administered. The policies in this document of a common theme of accountability and transparency. We believe that posts should only be deleted under certain circumstances, and all logs of what the admins are doing and discussing should be public.
+
+## Management of Administration
+
+- We will increase the number of admins per term as the current admin team sees fit. This will not be based on any ratios (i.e. 1 admin per 500 users), but based on how many bad posts are getting by unmoderated. If all bad posts are caught within some small amount of time (i.e. 30 minutes) of posting, then we have enough admins
+- The length of a term for an admin will be 3 months
+- An admin can serve for a maximum of two consecutive terms, but there is no maximum limit on the number of terms an admin can serve for
+- All admin activity will be public. In the case of bans, see the ban policy later in this document. For larger, more official meetings, either the entire chat log will be posted (possibly as a Github commit or a gist), or paraphrased meeting minutes. Small, one-off conversations/meetings do not need to be public.
+
+## Electing Admins
+
+[TODO: Ian, fill this in]
+
+## Purpose of Administration
+
+- Lock/close posts (and remove when content policy specifies).
+- Ban users and deal with ban appeals (see the ban policy for more details).
+- Manage the group name/cover photo and its promotion.
+
+Note that there are many tasks such as Hackbot administration, Github projects, etc. that do not need to be solely managed by admins.
+
+## Post deletion
+
+We believe that posts should only be deleted in a few specific cases. First of all, any spam from hacked accounts or bots will be deleted. Second, any posts violating Facebook's content policies will also be deleted. Finally, content can be deleted by an admin if the content is harassing a *specific* user, and that user requests that the content be removed. Note that generally objectionable content that does not target a *specific* user will not be removed (unless it violates Facebook's content policies), and will only be closed instead.
+
+All other content will be closed. The reason for this is to provide transparency as to what the admins deem to be bad content, and to leave examples of bad content in the group in an "archived" state so they can be used as examples of what not to post, as well as serving as precedent for closing future bad posts.
+
+## Ban Policy
+
+You may be banned by violating any of the rules defined in the content policy. A warning may be given first depending on the which policy was violated and the severity of the violation.
+
+When a user is banned, they have a chance to return to the group. They must make a post in Hackers
+Ban Appeals (not created yet), to argue why they shouldn’t be banned, or to apologize and request that they be re-added. If the user is not apologetic or we (the admins) and the community (jointly) do not agree with the user’s justification for their behavior, they will be banned from Hackers Ban Appeals and no further appealing can take place. Further policy violations in the main group after being re-added will result in immediate ban from both groups with no chance of appealing.
+
+The purpose of this process is both to give users a second chance, and to have a public space to discuss whether the actions of an admin were justified. Thus, it will not be possible for admins to silently ban individuals for no reasons. If an admin does this and immediately bans the user from the appeals group as well, the admin who did this will be immediately removed from their position as soon as this comes to light in the main group (which can be done by another member).
+
+## GitHub
+
+[TODO: Ian, fill this in]

--- a/admin-policy.md
+++ b/admin-policy.md
@@ -13,7 +13,16 @@ This posts documents how the HX group will be run and administered. The policies
 
 ## Electing Admins
 
-[TODO: Ian, fill this in]
+- The group will have a maintainer for a voting web interface.
+  - The web interface maintainer can be removed and replaced via an unanimous vote among the current elected admins.
+  - The web interface maintainer is responsible for producing the results of the election for each cycle, ensuring the voting application is secure, and maintaining its reliability. 
+  - The voting system will securely generate a v4 UUID for each user after they cast their first vote. When the user votes, their UUID will be stored along with their vote. When the election concludes, the UUID and vote will be published to allow auditing of the results.
+  - A future iteration of this system/document may not be able to connect UUIDs to Facebook profiles, however it is currently stored to facilitate an audit log of votes if needed. The system will never publish the connection of UUIDs to profiles.
+- The current admin team will determine how many admins are elected for the next term. This number must be above zero and less than ten.
+- 14 days before the end of a term, the web interface will allow candidates to mark themselves as running. 
+- 7 days before the end of a term, the web interface will allow group members to vote for a candidate. 
+- Votes will stop being accepted after 11:59PM GMT on the day the term ends. The current admins will use the voting result to add/remove themselves, if needed.
+- The voting system will publish a freely downloadable list of UUIDs and their vote after votes stop being accepted.
 
 ## Purpose of Administration
 

--- a/content-policy.md
+++ b/content-policy.md
@@ -1,0 +1,104 @@
+# HX Content Policy
+
+## Introduction
+
+This document describes the types of content that is acceptable in the [Hackers](https://www.facebook.com/groups/wearehx/) Facebook group. Hackers (HX) is a bit different from other Facebook groups, so we'd appreciate it if you'd take a minute to read this.
+
+TL;DR: Be civil, and keep posts relevant to hacking: creating and building new things, discussing things related to hacking, and celebrating hacker culture. Use the search bar first.
+
+HX is an experiment. As a common trend, a community site that becomes popular will decline in quality. Our hypothesis is that by making a conscious effort to resist decline, we can prevent Hackers from falling into this trend.  We don't know whether this hypothesis is correct, but it has held up for a surprisingly long time already.
+
+The most important principle on HX is to be thoughtful - civil and substantial.  Essentially there are two rules here: don't post crap, and don't be rude. Both types of posts will be closed swiftly, and if you continue to post them, you might be banned from the group.
+
+An insightful comment can point out some consideration that hadn't previously been mentioned, perhaps from personal experience.  There's also nothing wrong with submitting a comment saying just "Thanks" if you believe it would be more polite than simply liking the post/comment.  That said, what we especially discourage are comments that are empty and negative: name-calling, derailing the conversation, spam, etc.
+
+A crap post is one that does not genuinely add value to the community. Keep in mind that your post may show up in the feed of thousands of other members.  Posts on HX don’t have to be about hackathons, because good hackers aren’t only interested in hacking, but they do have to be something Hackers would enjoy or find interesting.
+
+When having discussions, remember to respect each other and take the opinion of the other side  into account instead of name-calling or insulting the other person. It is okay to be offended, but it is not okay to be purposefully offensive.  We give everybody the same level of respect.
+
+If a post doesn’t follow the rules, an admin will lock it. If an admin judges your repeated behavior to be intentionally against the rules, you may be banned. We’ll delete posts that break Facebook’s guidelines. See the Administration Policy document for more details.
+
+## What makes a post great for HX?
+
+Note that just because a post is good, doesn’t mean a thread is good. If a thread devolves into a flamewar, it might be deleted or locked. Also note that reposting an on-topic post makes it a bad post and violates this content policy.
+
+### Announcements, hackathons, news
+
+- "Hey everyone, register for HackBCA!"
+- "Who’s going to PennApps?" or "Anyone going to the Thiel Summit in SF?"
+
+Please be sure to do a search before doing these types of posts.
+
+### Discussions on technologies, tools, or hacker culture
+
+Intelligent, constructive discussion about technology is awesome, as long as it is just that — not a flamewar. Please do a search before posting to see if similar discussions have already happened. If the discussion has already happened, please post your thoughts on the original thread. Otherwise, go ahead and make the new post.
+
+- "Does anyone know how I can get an AP computer science class at my high school?"
+- "I just read 'Learning C the Hard Way' and it gave me a unique perspective on ___________.  I’d recommend getting a copy if you ____________.""
+-- Gives advice rather than asking whether X is good or bad.
+- "Hmm, I just received a DMCA takedown request for content in one of my GitHub repos. Anyone have experience dealing with these before?"
+Even if this has been discussed in the past, it’s always great to have an up-to-date discussion on issues like this.
+- "Saw this neat article about a band that released an album as a Linux Kernel!" http://m.networkworld.com/community/blog/band-releases-album-linux-kernel-module
+- "For those of you who haven’t seen this before, someone just ported "power mode" over to Atom! https://atom.io/packages/activate-power-mode"
+- "I don’t like how MLH handled this issue at a hackathon."
+[TODO: What about social posts, like https://www.facebook.com/groups/1659221770989008/permalink/1706491326262052/? I personally think that posts like this should not go in the group. They should either go in a subgroup for social posts, or go in the ##hx irc channel.]
+
+Note that discussions about the way the group is being run should be posted in HX Meta. Please be civil with your comments.
+
+### Celebrating personal projects, start-ups
+
+If you’ve got a hack or project you want to show off, AWESOME!
+
+"Thanks so much to all you guys who helped me with the launch of 4 Snaps and who downloaded my game today on the first day! The app is now #1 in the US Top Word Games chart and 105 Overall charts! Thanks so much guys!!!!"
+
+"Congrats to my friend Ryan for a great interview on Android Authority! Definitely a source of inspiration for all high schoolers looking into Computer Science!"
+-- Awesome! Sharing press articles about fellow Hackers is definitely encouraged!
+- "So my friends (Harvard drop outs) built Fiveprep. It's a tool to help you study APUSH (pretty much quizup for apush). I know the test is coming up in less than a week so I hope you all get 5s! http://fiveprep.com/"
+-- This is is a technological tool for high schoolers. Awesome.
+"Hey guys! On 5/14/14 Alex, Paul, Aakash and myself will be releasing the private beta of HackerBracket, a community for sharing hacks through video presentations. Video encoding + our hosting becomes pretty expensive at a base price of $50/month. I would really appreciate it if you support us by pre-ordering an early pro account for $10/year. Get it here: https://gumroad.com/l/hackerbracket"
+-- This was asked nicely, prices were disclosed up front, and it was made by community members. No harm here.
+
+### What makes a post bad?
+
+- Don’t post irrelevant things or spam: "Can you help me hack someone’s account?"
+-- Absolutely not. We’re not those kinds of hackers.
+- "Hey!  I just heard about this new service called Amazon Prime, you can get it for free with your University email address: http://example.com/referral/aIn9xP/"
+-- If your motivation for sharing a service with us is to get money or points, it’s spam and you will be warned not to try it again.
+- "Does someone have a free Namecheap coupon?"
+-- Ask in HS Offers. 90% of the time the there is already an existing subgroup for what you're looking for.
+- "Where can I download the latest episode of Silicon Valley for free?"
+-- Copyright infringement is unwanted in this group.
+- "Can someone recommend me a good pair of headphone?"
+-- No.
+- "Hi! I just got an offer from two different companies and here’s my really specific situation and what should I do?"
+--Ask in [TODO: there’s a group for this, right?]
+[TODO: Is politics off topic? I can see many forms of bad politics post in this group, i.e. "Donald Trump said blah", but there can be many forms of good post, i.e. "There’s a vote on this net neutrality law tonight. Here’s an article explaining what’s going on".]
+
+### Don’t use HX as a Tech Support Forum
+
+Don’t post something that is readily available online. HX is not a tech support forum, nor is it the place to go if StackOverflow gives you a negative rating.  There are specific subgroups for most technical topics. Also, nobody else wants any of the following questions in their Facebook feed:
+- "How do I use GitHub Pages?"
+- "Can anyone help me with some JavaScript errors I’m getting? Thanks!"
+- "Haas anyone used the Twitter API before? IM me!"
+
+### Don’t forget about the search bar.
+
+Any of the following posts are either readily answerable through Google or searching older posts.
+- Has anyone ever done a phone interview with Google before?
+- What should I use for basic hosting?
+-- Static sites (HTML/CSS/JS only): If your site is static, then you should use Github Pages. Here is a guide on how to set that up: https://pages.github.com/ This option is free.
+-- Dynamic Sites: People typically use Heroku for quick setup for dynamic sites.
+- What should I use for domain registration?
+-- For paid domain registration, Namecheap is a nice deal. Domain.com usually gives out free domains at MLH-backed events.
+
+### Don’t make overly vague/unhelpful posts
+
+Vague posts pollute their comments instantly as people ask for more information that should have been in the original post. Include everything you would ask if you saw your post asked by someone else.
+- "Anyone interested in helping me with a new startup, IM me!"
+-- What startup? What is your idea? What is the position? What is the location? What is the technology? What qualities are you looking for? Why should someone help you? What do you get out of it? Who’s involved? (You probably shouldn’t keep these secret either. See: http://www.paulgraham.com/ideas.html)
+- "Thoughts?" + attached link
+-- Start off the discussion with your own thoughts! Please provide more specific information on how it relates to HX.
+
+### Jokes and Memes
+
+[TODO: Really the only jokes I have a problem with are reposted jokes, but I want to see what the community thinks here.]


### PR DESCRIPTION
Line 9 gives admins too much power. Line 9 also contradicts itself. Line 9 states that the ammount of admins ammount should "not be based on any ratios" but then line 9 then states that  the admin ammount should be "based on how many bad posts are getting by unmoderated". So we do need a ratio. A bad post to admin ratio. And then we need to determine how many posts an indivdual admin can moderate on a daily/weekly basis.
